### PR TITLE
Refactor Ciphersuite taproot methods for universal applicability

### DIFF
--- a/frost-core/src/batch.rs
+++ b/frost-core/src/batch.rs
@@ -118,12 +118,8 @@ where
 
         for item in self.signatures.iter() {
             let z = item.sig.z;
-            let mut R = item.sig.R;
-            let mut vk = item.vk.element;
-            if <C>::is_taproot_compat() {
-                R = <C>::taproot_compat_R(&item.sig.R);
-                vk = <C>::tweaked_public_key(&item.vk.element);
-            }
+            let R = <C>::effective_nonce_element(item.sig.R);
+            let vk = <C>::effective_pubkey_element(&item.vk);
 
             let blind = <<C::Group as Group>::Field>::random(&mut rng);
 

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -588,19 +588,12 @@ where
         z = z + signature_share.share;
     }
 
-    if <C>::is_taproot_compat() {
-        let challenge = <C>::challenge(
-            &group_commitment.0,
-            &pubkeys.verifying_key,
-            signing_package.message().as_slice(),
-        );
-        z = <C>::aggregate_tweak_z(z, &challenge, &pubkeys.verifying_key.element);
-    }
-
-    let signature = Signature {
-        R: group_commitment.0,
+    let signature: Signature<C> = <C>::aggregate_sig_finalize(
         z,
-    };
+        group_commitment.0,
+        &pubkeys.verifying_key,
+        signing_package.message().as_slice(),
+    );
 
     // Verify the aggregate signature
     let verification_result = pubkeys

--- a/frost-core/src/round1.rs
+++ b/frost-core/src/round1.rs
@@ -350,6 +350,14 @@ where
 #[derive(Clone, Copy, PartialEq)]
 pub struct GroupCommitmentShare<C: Ciphersuite>(pub(super) Element<C>);
 
+impl<C: Ciphersuite> GroupCommitmentShare<C> {
+    /// Return the underlying element.
+    #[cfg_attr(feature = "internals", visibility::make(pub))]
+    pub(crate) fn to_element(self) -> Element<C> {
+        self.0
+    }
+}
+
 /// Encode the list of group signing commitments.
 ///
 /// Implements [`encode_group_commitment_list()`] from the spec.

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -68,12 +68,9 @@ where
         //                 h * ( z * B - c * A - R) == 0
         //
         // where h is the cofactor
-        let mut R = signature.R;
-        let mut vk = self.element;
-        if <C>::is_taproot_compat() {
-            R = <C>::taproot_compat_R(&signature.R);
-            vk = <C>::tweaked_public_key(&self.element);
-        }
+        let R = C::effective_nonce_element(signature.R);
+        let vk = C::effective_pubkey_element(&self);
+
         let zB = C::Group::generator() * signature.z;
         let cA = vk * challenge.0;
         let check = (zB - cA - R) * C::Group::cofactor();


### PR DESCRIPTION
The taproot compatibility methods added to Ciphersuite were very specific to taproot. I renamed them, and tidied up their usage to remove unnecessary if/else branches. This should make them applicable to any ciphersuite which needs to modify such internal processes of the FROST algorithm.

This change should be a pure refactor with no logical changes.

A full list of the renames of `Ciphersuite` methods:

- `tweaked_secret_key` -> `effective_secret_key`
- `taproot_compat_R` -> `effective_nonce_element`
- `tweaked_public_key` -> `effective_pubkey_element`
- `taproot_compat_nonce` -> `effective_nonce_secret`
- `aggregate_tweak_z` -> `finalize_aggregated_signature`
- `tweak_z` -> `finalize_single_signature`
- `taproot_compat_commitment_share` -> `effective_commitment_share`
- `taproot_compat_verifying_share` -> `effective_verifying_share`
- `compute_taproot_compat_signature_share` -> `compute_signature_share`
- `is_taproot_compat` -> REMOVED