### PR TITLE
cover taproot-tweaked signing with integration tests

### DIFF
--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -646,7 +646,7 @@ where
     // Verify the aggregate signature
     let verification_result = pubkeys
         .verifying_key
-        .verify(signing_package.message(), &signature);
+        .verify(signing_package.sig_target.clone(), &signature);
 
     // Only if the verification of the aggregate signature failed; verify each share to find the cheater.
     // This approach is more efficient since we don't need to verify all shares

--- a/frost-core/src/traits.rs
+++ b/frost-core/src/traits.rs
@@ -264,7 +264,6 @@ pub trait Ciphersuite: Copy + Clone + PartialEq + Debug {
         signature: &Signature<Self>,
         public_key: &VerifyingKey<Self>,
     ) -> Result<(), Error<Self>> {
-        let sig_target = sig_target.into();
         let c = <Self>::challenge(&signature.R, public_key, sig_target);
 
         public_key.verify_prehashed(c, signature, &sig_target.sig_params)

--- a/frost-core/src/traits.rs
+++ b/frost-core/src/traits.rs
@@ -393,6 +393,6 @@ pub trait Ciphersuite: Copy + Clone + PartialEq + Debug {
         _verifying_key: &VerifyingKey<Self>,
         _sig_params: &Self::SigningParameters,
     ) -> <Self::Group as Group>::Element {
-        verifying_share.to_element()
+        verifying_share.0
     }
 }

--- a/frost-ed25519/tests/integration_tests.rs
+++ b/frost-ed25519/tests/integration_tests.rs
@@ -12,7 +12,10 @@ fn check_zero_key_fails() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed25519Sha512, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed25519Sha512, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -68,7 +71,10 @@ fn check_rts() {
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed25519Sha512, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed25519Sha512, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -220,7 +226,7 @@ fn check_sign_with_dealer_and_identifiers() {
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Ed25519Sha512,
         _,
-    >(rng);
+    >(rng, b"message".into());
 }
 
 #[test]

--- a/frost-ed25519/tests/interoperability_tests.rs
+++ b/frost-ed25519/tests/interoperability_tests.rs
@@ -12,12 +12,13 @@ fn check_interoperability_in_sign_with_dkg() {
     // and the interoperability check. A smaller number of iterations is used
     // because DKG takes longer and otherwise the test would be too slow.
     for _ in 0..32 {
-        let (msg, group_signature, group_pubkey) =
+        let (target, group_signature, group_pubkey) =
             frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed25519Sha512, _>(
                 rng.clone(),
+                b"message".into(),
             );
 
-        helpers::verify_signature(&msg, group_signature, group_pubkey);
+        helpers::verify_signature(target.message(), group_signature, group_pubkey);
     }
 }
 
@@ -28,13 +29,14 @@ fn check_interoperability_in_sign_with_dealer() {
     // Test with multiple keys/signatures to better exercise the key generation
     // and the interoperability check.
     for _ in 0..256 {
-        let (msg, group_signature, group_pubkey) =
+        let (target, group_signature, group_pubkey) =
             frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed25519Sha512, _>(
                 rng.clone(),
+                b"message".into(),
             );
 
         // Check that the threshold signature can be verified by the `ed25519_dalek` crate
         // public key (interoperability test)
-        helpers::verify_signature(&msg, group_signature, group_pubkey);
+        helpers::verify_signature(target.message(), group_signature, group_pubkey);
     }
 }

--- a/frost-ed448/tests/integration_tests.rs
+++ b/frost-ed448/tests/integration_tests.rs
@@ -12,7 +12,10 @@ fn check_zero_key_fails() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed448Shake256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed448Shake256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -68,7 +71,10 @@ fn check_rts() {
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed448Shake256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed448Shake256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -220,7 +226,7 @@ fn check_sign_with_dealer_and_identifiers() {
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Ed448Shake256,
         _,
-    >(rng);
+    >(rng, b"message".into());
 }
 
 #[test]

--- a/frost-p256/tests/integration_tests.rs
+++ b/frost-p256/tests/integration_tests.rs
@@ -12,7 +12,10 @@ fn check_zero_key_fails() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<P256Sha256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<P256Sha256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -68,7 +71,10 @@ fn check_rts() {
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<P256Sha256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<P256Sha256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -217,6 +223,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<P256Sha256, _>(
         rng,
+        b"message".into(),
     );
 }
 

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -12,7 +12,10 @@ fn check_zero_key_fails() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ristretto255Sha512, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ristretto255Sha512, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -68,7 +71,10 @@ fn check_rts() {
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ristretto255Sha512, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ristretto255Sha512, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -220,7 +226,7 @@ fn check_sign_with_dealer_and_identifiers() {
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Ristretto255Sha512,
         _,
-    >(rng);
+    >(rng, b"message".into());
 }
 
 #[test]

--- a/frost-secp256k1-tr/tests/integration_tests.rs
+++ b/frost-secp256k1-tr/tests/integration_tests.rs
@@ -12,7 +12,10 @@ fn check_zero_key_fails() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -68,7 +71,10 @@ fn check_rts() {
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -220,7 +226,7 @@ fn check_sign_with_dealer_and_identifiers() {
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Secp256K1Sha256,
         _,
-    >(rng);
+    >(rng, b"message".into());
 }
 
 #[test]

--- a/frost-secp256k1-tr/tests/tweaking_tests.rs
+++ b/frost-secp256k1-tr/tests/tweaking_tests.rs
@@ -1,0 +1,89 @@
+use frost_secp256k1_tr::*;
+use rand::thread_rng;
+
+#[test]
+fn check_tweaked_signing_key() {
+    let signing_key = SigningKey::deserialize([0xAA; 32]).unwrap();
+    let untweaked_verifying_key = VerifyingKey::from(signing_key);
+
+    let mut rng = rand::thread_rng();
+    let message = b"message";
+
+    let untweaked_signature = signing_key.sign(&mut rng, &message);
+
+    untweaked_verifying_key
+        .verify(&message, &untweaked_signature)
+        .expect("untweaked signature should be valid under untweaked verifying key");
+
+    let signing_target = SigningTarget::new(
+        &message,
+        SigningParameters {
+            tapscript_merkle_root: Some(vec![]),
+        },
+    );
+
+    let tweaked_signature = signing_key.sign(&mut rng, signing_target.clone());
+
+    untweaked_verifying_key
+        .verify(&message, &tweaked_signature)
+        .expect_err("tweaked signature should not be valid under untweaked verifying key");
+
+    let tweaked_verifying_key = untweaked_verifying_key.effective_key(signing_target.sig_params());
+    tweaked_verifying_key
+        .verify(&message, &tweaked_signature)
+        .expect("tweaked signature should be valid under tweaked verifying key");
+
+    untweaked_verifying_key
+        .verify(signing_target.clone(), &tweaked_signature)
+        .expect(
+            "tweaked signature should be valid under untweaked verifying key\
+             when signing params are provided",
+        );
+}
+
+#[test]
+fn check_tweaked_sign_with_dkg() {
+    let rng = thread_rng();
+
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256, _>(
+        rng,
+        SigningTarget::new(
+            b"message",
+            SigningParameters {
+                tapscript_merkle_root: Some(vec![]),
+            },
+        ),
+    );
+}
+#[test]
+fn check_tweaked_sign_with_dealer() {
+    let rng = thread_rng();
+
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256, _>(
+        rng,
+        SigningTarget::new(
+            b"message",
+            SigningParameters {
+                tapscript_merkle_root: Some(vec![]),
+            },
+        ),
+    );
+}
+
+#[test]
+fn check_tweaked_sign_with_dealer_and_identifiers() {
+    let rng = thread_rng();
+
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
+        Secp256K1Sha256,
+        _,
+    >(
+        rng,
+        SigningTarget::new(
+            b"message",
+            SigningParameters {
+                tapscript_merkle_root: Some(vec![]),
+            },
+        ),
+    );
+}

--- a/frost-secp256k1/tests/integration_tests.rs
+++ b/frost-secp256k1/tests/integration_tests.rs
@@ -12,7 +12,10 @@ fn check_zero_key_fails() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -68,7 +71,10 @@ fn check_rts() {
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256, _>(rng);
+    frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256, _>(
+        rng,
+        b"message".into(),
+    );
 }
 
 #[test]
@@ -220,7 +226,7 @@ fn check_sign_with_dealer_and_identifiers() {
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Secp256K1Sha256,
         _,
-    >(rng);
+    >(rng, b"message".into());
 }
 
 #[test]


### PR DESCRIPTION
Currently, https://github.com/ZcashFoundation/frost/pull/584 does not have any test coverage for taproot-tweaked signing. 

This PR adds integration test coverage for signing with a commitment to a tapscript merkle root, proving that we can sign as a given group verifying key both with and without a tweak.

This chunk of code added to `ciphersuite_generic.rs` demonstrates how we can provide the 'effective' (tweaked) verifying key, AKA the 'taproot output key'. An observer can use it to verify signatures without the verifier knowing the tweak value used.

```rust
// Check that the effective verifying key can be verified against the raw message,
// without exposing the SigningParameters.
pubkey_package
    .verifying_key
    .effective_key(signing_target.sig_params())
    .verify(signing_target.message(), &group_signature)?;
```

I fixed a couple of minor mistakes in the first three commits. [This commit specifically](48840def2b9aee9b5c8e566e8e6e7847358bed3c) fixes the issue which @MatthewLM reported [here](https://github.com/ZcashFoundation/frost/pull/584#issuecomment-1998419114).


