### PR TITLE
reexported frost core internals

### DIFF
--- a/frost-secp256k1-tr/src/lib.rs
+++ b/frost-secp256k1-tr/src/lib.rs
@@ -29,7 +29,7 @@ mod tests;
 
 // Re-exports in our public API
 pub use frost_core::{
-    serde, Challenge, Ciphersuite, Element, Field, FieldError, Group, GroupCommitment, GroupError,
+    self, serde, Challenge, Ciphersuite, Element, Field, FieldError, Group, GroupCommitment, GroupError,
 };
 
 pub use rand_core;


### PR DESCRIPTION
reexport frost core with internals features in order to verify single signature shares before aggregation.